### PR TITLE
Epic/google analytics setup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -102,3 +102,6 @@ dist
 
 # TernJS port file
 .tern-port
+
+# Env
+.env.local

--- a/additional.d.ts
+++ b/additional.d.ts
@@ -1,0 +1,3 @@
+declare interface Window {
+	gtag: function
+}

--- a/next.env.d.ts
+++ b/next.env.d.ts
@@ -1,2 +1,0 @@
-/// <reference types="next" />
-/// <reference types="next/types/global" />

--- a/src/lib/gtag/analytics.tsx
+++ b/src/lib/gtag/analytics.tsx
@@ -1,0 +1,36 @@
+/*
+ * Google Analytics
+ *
+ * Initialiszes Google Analytics
+ *
+ * @see https://github.com/vercel/next.js/tree/canary/examples/with-google-analytics
+ * @returns {JSX.Element}
+*/
+
+import Script from 'next/script'
+import { GA_TRACKING_ID } from '.'
+
+export const GoogleAnalytics = (): JSX.Element => {
+	return (
+		<>
+			<Script
+				strategy="afterInteractive"
+				src={`https://www.googletagmanager.com/gtag/js?id=${GA_TRACKING_ID}`}
+			/>
+			<Script
+				id="gtag-init"
+				strategy="afterInteractive"
+				dangerouslySetInnerHTML={{
+					__html: `
+						window.dataLayer = window.dataLayer || [];
+						function gtag(){dataLayer.push(arguments);}
+						gtag('js', new Date());
+						gtag('config', '${GA_TRACKING_ID}', {
+							page_path: window.location.pathname,
+						});
+					`,
+				}}
+			/>
+		</>
+	)
+}

--- a/src/lib/gtag/index.ts
+++ b/src/lib/gtag/index.ts
@@ -1,0 +1,22 @@
+interface sendEventProps {
+	action: string,
+	category: string,
+	label: string,
+	value: string | number
+}
+
+export const GA_TRACKING_ID = process.env.NEXT_PUBLIC_GA_ID
+
+export const sendPageView = (url: string) => {
+	window.gtag('config', GA_TRACKING_ID, {
+		page_path: url,
+	})
+}
+
+export const sendEvent = ({ action, category, label, value }: sendEventProps) => {
+	window.gtag('event', action, {
+		event_category: category,
+		event_label: label,
+		value: value,
+	})
+}

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -9,21 +9,41 @@
 */
 
 import type { AppProps } from 'next/app'
+import { useRouter } from 'next/router'
+import { useEffect } from 'react'
 import { DefaultSeo } from 'next-seo';
 import Layout from '@components/Layout'
 import ErrorBoundary from '@components/ErrorBoundary'
 import 'tailwindcss/tailwind.css'
+import { sendPageView } from '@lib/gtag'
+import { GoogleAnalytics } from '@lib/gtag/analytics';
 
 import SEO from '../next-seo.config';
 
 export default function MyApp({ Component, pageProps }: AppProps) {
+	const router = useRouter()
+
+	useEffect(() => {
+		const handleRouteChange = (url: string) => {
+			sendPageView(url)
+		}
+
+		router.events.on('routeChangeComplete', handleRouteChange)
+		router.events.on('hashChangeComplete', handleRouteChange)
+
+		return () => {
+			router.events.off('routeChangeComplete', handleRouteChange)
+			router.events.off('hashChangeComplete', handleRouteChange)
+		}
+	}, [router.events])
+
 	return (
 		<Layout>
 			<ErrorBoundary>
 				<DefaultSeo {...SEO} />
+				<GoogleAnalytics />
 				<Component {...pageProps} />
 			</ErrorBoundary>
 		</Layout>
-
 	)
 }


### PR DESCRIPTION
This PR takes care of installing Google Analytics into the site:

- Setup an `env` variable to keep tracking id safe
- Install Google Analytics
- Setup page view and event methods

Adapted from https://github.com/vercel/next.js/tree/canary/examples/with-google-analytics